### PR TITLE
fix: prevent invalid mouse button value when selecting text and dragging mouse

### DIFF
--- a/addon/event.py
+++ b/addon/event.py
@@ -287,7 +287,7 @@ class HotmouseEventFilter(QObject):
                 if manager.on_mouse_press(event):
                     return True
             elif event.type() == QEvent.Type.MouseButtonRelease:
-                if manager.enabled:
+                if manager.enabled and event.button() != Qt.MouseButton.NoButton:
                     btn = Button(event.button())
                     # Prevent back/forward navigation
                     if btn == Button.xbutton1 or btn == Button.xbutton2:


### PR DESCRIPTION
This is a simple quick fix to close issue https://github.com/BlueGreenMagick/Review-Hotmouse/issues/32